### PR TITLE
SUPESC-603 Fixed product category order overriding during data import

### DIFF
--- a/src/Pyz/Zed/DataImport/Business/Model/ProductAbstract/ProductAbstractHydratorStep.php
+++ b/src/Pyz/Zed/DataImport/Business/Model/ProductAbstract/ProductAbstractHydratorStep.php
@@ -262,16 +262,12 @@ class ProductAbstractHydratorStep implements DataImportStepInterface
                 ));
             }
 
-            $productOrder = 0;
+            $productCategoryEntityTransfer = (new SpyProductCategoryEntityTransfer())
+                ->setFkCategory($dataSet[static::COLUMN_CATEGORY_KEYS][$categoryKey]);
 
-            if (count($categoryProductOrder) && isset($categoryProductOrder[$index])) {
-                $productOrder = (int)$categoryProductOrder[$index];
+            if (count($categoryProductOrder) && isset($categoryProductOrder[$index]) && $categoryProductOrder[$index] !== '') {
+                $productCategoryEntityTransfer->setProductOrder((int)$categoryProductOrder[$index]);
             }
-
-            $productCategoryEntityTransfer = new SpyProductCategoryEntityTransfer();
-            $productCategoryEntityTransfer
-                ->setFkCategory($dataSet[static::COLUMN_CATEGORY_KEYS][$categoryKey])
-                ->setProductOrder($productOrder);
 
             $productCategoryTransfers[] = [
                 static::COLUMN_ABSTRACT_SKU => $dataSet[static::COLUMN_ABSTRACT_SKU],


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/SUPESC-603

###### Change log

- Fixed product abstract data import so it will not override product category order in DB when it is not specified in the data import file.