### PR TITLE
FRW-10093 Use Mailpit as standard mail-catcher.

### DIFF
--- a/deploy.aop-b2c-testing.yml
+++ b/deploy.aop-b2c-testing.yml
@@ -225,7 +225,7 @@ services:
         endpoints:
             jenkins.aop-b2c-testing.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.aop-b2c-testing.demo-spryker.com:
 

--- a/deploy.aop-demoshop-b2c.yml
+++ b/deploy.aop-demoshop-b2c.yml
@@ -185,7 +185,7 @@ services:
         endpoints:
             scheduler.aop-b2c.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.aop-b2c.demo-spryker.com:
 

--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -176,7 +176,7 @@ services:
         endpoints:
             scheduler.example.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.example.demo-spryker.com:
 

--- a/deploy.ci.acceptance.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.dynamic-store-off.yml
@@ -169,7 +169,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
     webdriver:
         engine: chromedriver
 

--- a/deploy.ci.acceptance.mariadb.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.cypress.yml
@@ -134,7 +134,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
 
 docker:
     ssl:

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
@@ -177,7 +177,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
 
 docker:
     ssl:

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
@@ -170,7 +170,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
 
 docker:
     ssl:

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
@@ -152,7 +152,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
     webdriver:
         engine: chromedriver
 

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -119,7 +119,7 @@ services:
         version: '2.442'
         csrf-protection-enabled: true
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
     webdriver:
         engine: chromedriver
 

--- a/deploy.ci.acceptance.mariadb.robot.yml
+++ b/deploy.ci.acceptance.mariadb.robot.yml
@@ -128,7 +128,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
 
 docker:
     ssl:

--- a/deploy.ci.acceptance.mariadb.yml
+++ b/deploy.ci.acceptance.mariadb.yml
@@ -115,7 +115,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
     webdriver:
         engine: chromedriver
 

--- a/deploy.ci.acceptance.yml
+++ b/deploy.ci.acceptance.yml
@@ -111,7 +111,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
     webdriver:
         engine: chromedriver
 

--- a/deploy.ci.api.mariadb.robot.yml
+++ b/deploy.ci.api.mariadb.robot.yml
@@ -114,7 +114,7 @@ services:
         engine: elastic
         version: '7.10'
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
 
 docker:
     ssl:

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -118,7 +118,7 @@ services:
         version: '2.442'
         csrf-protection-enabled: true
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
     webdriver:
         engine: chromedriver
 

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -276,7 +276,7 @@ services:
         endpoints:
             scheduler.spryker.local:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker.local:
     swagger:

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -225,7 +225,7 @@ services:
         endpoints:
             scheduler.spryker.local:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker.local:
     swagger:

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -257,7 +257,7 @@ services:
         endpoints:
             scheduler.spryker.local:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker.local:
     swagger:

--- a/deploy.scos2-b2cmp.yml
+++ b/deploy.scos2-b2cmp.yml
@@ -180,7 +180,7 @@ services:
         endpoints:
             scheduler.spryker-b2cmp.cloud.spryker.toys:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker-b2cmp.cloud.spryker.toys:
 

--- a/deploy.spryker-b2c-eu.yml
+++ b/deploy.spryker-b2c-eu.yml
@@ -192,7 +192,7 @@ services:
         endpoints:
             scheduler.b2c-staging-eu.cloud.spryker.toys:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.b2c-staging-eu.cloud.spryker.toys:
 

--- a/deploy.spryker-b2c-intt.yml
+++ b/deploy.spryker-b2c-intt.yml
@@ -147,7 +147,7 @@ services:
         endpoints:
             scheduler.internal-testing.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.internal-testing.demo-spryker.com:
 

--- a/deploy.spryker-b2c-intts.yml
+++ b/deploy.spryker-b2c-intts.yml
@@ -121,7 +121,7 @@ services:
         endpoints:
             scheduler.us.b2c.internal-testing.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.internal-testing.demo-spryker.com:
 

--- a/deploy.spryker-b2c-production.yml
+++ b/deploy.spryker-b2c-production.yml
@@ -194,7 +194,7 @@ services:
         endpoints:
             scheduler.b2c.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.b2c.demo-spryker.com:
 

--- a/deploy.spryker-b2c-staging.yml
+++ b/deploy.spryker-b2c-staging.yml
@@ -197,7 +197,7 @@ services:
         endpoints:
             scheduler.b2c.cloud.spryker.toys:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.b2c.cloud.spryker.toys:
 

--- a/deploy.spryker-b2c-us.yml
+++ b/deploy.spryker-b2c-us.yml
@@ -164,7 +164,7 @@ services:
         endpoints:
             scheduler.b2c-staging-us.cloud.spryker.toys:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.b2c-staging-us.cloud.spryker.toys:
 

--- a/deploy.spryker-b2csec.yml
+++ b/deploy.spryker-b2csec.yml
@@ -147,7 +147,7 @@ services:
         endpoints:
             scheduler.internal-security.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.internal-security.demo-spryker.com:
 

--- a/deploy.spryker-mpb2cintt.yml
+++ b/deploy.spryker-mpb2cintt.yml
@@ -198,7 +198,7 @@ services:
         endpoints:
             scheduler.mp-b2c.internal-testing.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.mp-b2c.internal-testing.demo-spryker.com:
 

--- a/deploy.spryker-scosb2cmp.yml
+++ b/deploy.spryker-scosb2cmp.yml
@@ -198,7 +198,7 @@ services:
         endpoints:
             scheduler.scos-b2cmp.sh01.demo-spryker.com:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.scos-b2cmp.sh01.demo-spryker.com:
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -226,7 +226,7 @@ services:
         endpoints:
             scheduler.spryker.local:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker.local:
     swagger:


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-10093

###### Change log

Replaced MailHog with Mailpit as standard mail-catcher service in deployment files.