### PR TITLE
Update Jenkins version to 2.493.2

### DIFF
--- a/deploy.aop-b2c-testing.yml
+++ b/deploy.aop-b2c-testing.yml
@@ -221,6 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: false
         endpoints:
             jenkins.aop-b2c-testing.demo-spryker.com:

--- a/deploy.aop-demoshop-b2c.yml
+++ b/deploy.aop-demoshop-b2c.yml
@@ -181,6 +181,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.aop-b2c.demo-spryker.com:

--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -173,6 +173,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.example.demo-spryker.com:
     mail_catcher:

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -115,7 +115,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -271,7 +271,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -220,7 +220,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -252,7 +252,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.scos2-b2cmp.yml
+++ b/deploy.scos2-b2cmp.yml
@@ -175,7 +175,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: false
         endpoints:
             scheduler.spryker-b2cmp.cloud.spryker.toys:

--- a/deploy.spryker-b2c-eu.yml
+++ b/deploy.spryker-b2c-eu.yml
@@ -189,6 +189,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.b2c-staging-eu.cloud.spryker.toys:
     mail_catcher:

--- a/deploy.spryker-b2c-intt.yml
+++ b/deploy.spryker-b2c-intt.yml
@@ -144,6 +144,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.internal-testing.demo-spryker.com:
     mail_catcher:

--- a/deploy.spryker-b2c-intts.yml
+++ b/deploy.spryker-b2c-intts.yml
@@ -118,6 +118,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.us.b2c.internal-testing.demo-spryker.com:
     mail_catcher:

--- a/deploy.spryker-b2c-production.yml
+++ b/deploy.spryker-b2c-production.yml
@@ -191,6 +191,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.b2c.demo-spryker.com:
     mail_catcher:

--- a/deploy.spryker-b2c-staging.yml
+++ b/deploy.spryker-b2c-staging.yml
@@ -194,6 +194,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.b2c.cloud.spryker.toys:
     mail_catcher:

--- a/deploy.spryker-b2c-us.yml
+++ b/deploy.spryker-b2c-us.yml
@@ -161,6 +161,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.b2c-staging-us.cloud.spryker.toys:
     mail_catcher:

--- a/deploy.spryker-b2csec.yml
+++ b/deploy.spryker-b2csec.yml
@@ -144,6 +144,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.internal-security.demo-spryker.com:
     mail_catcher:

--- a/deploy.spryker-mpb2cintt.yml
+++ b/deploy.spryker-mpb2cintt.yml
@@ -195,6 +195,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.mp-b2c.internal-testing.demo-spryker.com:
     mail_catcher:

--- a/deploy.spryker-scosb2cmp.yml
+++ b/deploy.spryker-scosb2cmp.yml
@@ -193,7 +193,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.scos-b2cmp.sh01.demo-spryker.com:

--- a/deploy.yml
+++ b/deploy.yml
@@ -221,7 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-10275

###### Change log

- Introduce Jenkins 2.492.3 as the default scheduler version.