### PR TITLE
OPS-4941 Updated RabbitMQ version.

### DIFF
--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -150,7 +150,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.dynamic-store-off.yml
@@ -157,7 +157,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.cypress.yml
@@ -122,7 +122,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
@@ -165,7 +165,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
@@ -158,7 +158,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
@@ -140,7 +140,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -103,7 +103,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.robot.yml
+++ b/deploy.ci.acceptance.mariadb.robot.yml
@@ -116,7 +116,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.yml
+++ b/deploy.ci.acceptance.mariadb.yml
@@ -103,7 +103,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.yml
+++ b/deploy.ci.acceptance.yml
@@ -99,7 +99,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.dynamic-store-off.yml
+++ b/deploy.ci.api.dynamic-store-off.yml
@@ -132,7 +132,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.api.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.api.mariadb.dynamic-store-off.yml
@@ -133,7 +133,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.api.mariadb.robot.yml
+++ b/deploy.ci.api.mariadb.robot.yml
@@ -102,7 +102,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.mariadb.yml
+++ b/deploy.ci.api.mariadb.yml
@@ -93,7 +93,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.yml
+++ b/deploy.ci.api.yml
@@ -93,7 +93,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.dynamic-store-off.yml
+++ b/deploy.ci.functional.dynamic-store-off.yml
@@ -118,7 +118,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.functional.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.functional.mariadb.dynamic-store-off.yml
@@ -119,7 +119,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -102,7 +102,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.mariadb.yml
+++ b/deploy.ci.functional.mariadb.yml
@@ -96,7 +96,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.yml
+++ b/deploy.ci.functional.yml
@@ -92,7 +92,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -248,7 +248,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -197,7 +197,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -229,7 +229,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.yml
+++ b/deploy.yml
@@ -198,7 +198,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/OPS-4941

###### Change log

- Updated RabbitMQ service version from 3.9 to 3.13 across all deployment configurations to ensure environment consistency and prevent version-related compatibility issues.
