### PR TITLE
Update composer dependencies: bump spryker/twig to 3.31.0 and twig/tw…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -64463,16 +64463,16 @@
         },
         {
             "name": "spryker/twig",
-            "version": "3.30.0",
+            "version": "3.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/twig.git",
-                "reference": "a30f5cdee22cd4c99785d11c4f573716a84455d8"
+                "reference": "0cf53ad55cf065e700d97f2017a52da3c479af6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/twig/zipball/a30f5cdee22cd4c99785d11c4f573716a84455d8",
-                "reference": "a30f5cdee22cd4c99785d11c4f573716a84455d8",
+                "url": "https://api.github.com/repos/spryker/twig/zipball/0cf53ad55cf065e700d97f2017a52da3c479af6b",
+                "reference": "0cf53ad55cf065e700d97f2017a52da3c479af6b",
                 "shasum": ""
             },
             "require": {
@@ -64518,9 +64518,9 @@
             ],
             "description": "Twig module",
             "support": {
-                "source": "https://github.com/spryker/twig/tree/3.30.0"
+                "source": "https://github.com/spryker/twig/tree/3.31.0"
             },
-            "time": "2026-04-02T14:44:32+00:00"
+            "time": "2026-05-20T13:29:28+00:00"
         },
         {
             "name": "spryker/twig-extension",
@@ -72838,16 +72838,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.24.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
-                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -72902,7 +72902,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -72914,7 +72914,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-17T21:31:11+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         },
         {
             "name": "voku/anti-xss",
@@ -79854,7 +79854,7 @@
         "ext-readline": "*",
         "ext-redis": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.13"
     },


### PR DESCRIPTION
…ig to v3.26.0

#### Overview

- Ticket: URL_HERE

###### Optional

- Core PR: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
