### PR TITLE
SUPESC-1115 Refresh cart items when a single item fails the pre-check

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -20601,16 +20601,16 @@
         },
         {
             "name": "spryker/cart",
-            "version": "7.17.0",
+            "version": "7.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cart.git",
-                "reference": "988cbdb80888c87114c1c76b60e275bcf6e8d93d"
+                "reference": "5c0c0e8b49e5d9e9135601292acf54cf38a050d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cart/zipball/988cbdb80888c87114c1c76b60e275bcf6e8d93d",
-                "reference": "988cbdb80888c87114c1c76b60e275bcf6e8d93d",
+                "url": "https://api.github.com/repos/spryker/cart/zipball/5c0c0e8b49e5d9e9135601292acf54cf38a050d3",
+                "reference": "5c0c0e8b49e5d9e9135601292acf54cf38a050d3",
                 "shasum": ""
             },
             "require": {
@@ -20662,9 +20662,9 @@
             ],
             "description": "Cart module",
             "support": {
-                "source": "https://github.com/spryker/cart/tree/7.17.0"
+                "source": "https://github.com/spryker/cart/tree/7.18.1"
             },
-            "time": "2026-04-26T19:28:31+00:00"
+            "time": "2026-07-29T09:54:53+00:00"
         },
         {
             "name": "spryker/cart-code",
@@ -80095,7 +80095,7 @@
         "ext-readline": "*",
         "ext-redis": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.13"
     },

--- a/src/Pyz/Zed/Cart/CartConfig.php
+++ b/src/Pyz/Zed/Cart/CartConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the Spryker Commerce OS.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Pyz\Zed\Cart;
+
+use Spryker\Zed\Cart\CartConfig as SprykerCartConfig;
+
+class CartConfig extends SprykerCartConfig
+{
+    public function isCartReloadOnPreCheckFailureEnabled(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/SUPESC-1115
- Suite PR: https://github.com/spryker/suite/pull/815

`Operation::reloadItemsInQuote()` ran the cart pre-check over all items at once and, on any single failure, returned a quote clone taken before expansion and recalculation. The whole cart then stayed stale indefinitely — wrong prices and totals — even though the error messages rendered correctly.

###### Change log

- `spryker/cart` 7.17.0 → 7.18.1
- `src/Pyz/Zed/Cart/CartConfig.php`: added (this project had no Pyz `CartConfig`), overriding `isCartReloadOnPreCheckFailureEnabled(): true`

The project override is required, not optional. Core defaults the flag to `false` for backward compatibility, so the package bump on its own changes nothing.

###### Test plan

- Put an item in the cart that trips a cart pre-check (availability or min-order-quantity), change a different item's price in the Back Office, then reload the cart. The error message must still show while the remaining items' prices and totals refresh.
- Regression check: with the flag removed, the cart must go back to showing stale totals.
- Verified locally on 7.18.1 that core's default is `false` and that `Pyz\Zed\Cart\CartConfig::isCartReloadOnPreCheckFailureEnabled()` resolves `true`.